### PR TITLE
Fixed a Collision Error

### DIFF
--- a/CS240 Platformer Project/src/Hero.java
+++ b/CS240 Platformer Project/src/Hero.java
@@ -16,8 +16,8 @@ public class Hero extends Creature {
 
 		bounds.x = 0;
 		bounds.y = 0;
-		bounds.width = 44;
-		bounds.height = 44;
+		bounds.width = 50;
+		bounds.height = 50;
 		// TODO Auto-generated constructor stub
 	}
 


### PR DESCRIPTION
The player would overlap into a stone tile when colliding with it on the right. I changed the bounds.width and bounds.height to 50, which solved the problem. There are other persisting collision problems though, so this is a small fix.